### PR TITLE
SchoolRepository에 관한 Service 구현

### DIFF
--- a/src/main/java/com/example/findmidschool/school/entity/School.java
+++ b/src/main/java/com/example/findmidschool/school/entity/School.java
@@ -25,4 +25,8 @@ public class School {
     private double latitude;
     private double longitude;
 
+    public void changeAddress(String address) {
+        this.schoolAddress = address;
+    }
+
 }

--- a/src/main/java/com/example/findmidschool/school/service/SchoolRepositoryService.java
+++ b/src/main/java/com/example/findmidschool/school/service/SchoolRepositoryService.java
@@ -1,0 +1,45 @@
+package com.example.findmidschool.school.service;
+
+import com.example.findmidschool.school.entity.School;
+import com.example.findmidschool.school.repository.SchoolRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SchoolRepositoryService {
+
+    private final SchoolRepository schoolRepository;
+
+    @Transactional
+    public void updateAddress(Long id, String address) {
+
+        School entity = schoolRepository.findById(id).orElse(null);
+
+        if (Objects.isNull(entity)) {
+            log.error("[SchoolRepositoryService updateAddress] not found id: {}", id);
+        }
+
+        entity.changeAddress(address);
+
+    }
+
+    // for test
+    public void updateAddressWithoutTransaction(Long id, String address) {
+
+        School entity = schoolRepository.findById(id).orElse(null);
+
+        if (Objects.isNull(entity)) {
+            log.error("[SchoolRepositoryService updateAddress] not found id: {}", id);
+        }
+
+        entity.changeAddress(address);
+
+    }
+
+}

--- a/src/test/groovy/com/example/findmidschool/school/service/SchoolRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/example/findmidschool/school/service/SchoolRepositoryServiceTest.groovy
@@ -1,0 +1,66 @@
+package com.example.findmidschool.school.service
+
+import com.example.findmidschool.AbstractIntegrationContainerBaseTest
+import com.example.findmidschool.school.entity.School
+import com.example.findmidschool.school.repository.SchoolRepository
+import org.springframework.beans.factory.annotation.Autowired
+
+class SchoolRepositoryServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private SchoolRepositoryService sut
+
+    @Autowired
+    private SchoolRepository schoolRepository
+
+    def setup() {
+        schoolRepository.deleteAll()
+    }
+
+    def "schoolRepository update - dirty checking success"() {
+
+        given:
+        String inputAddress = "의왕시 오전동"
+        String modifiedAddress = "의왕시 고천동"
+        String name = "모락중학교"
+
+        def school = School.builder()
+                .schoolAddress(inputAddress)
+                .schoolName(name)
+                .build()
+
+        when:
+        def entity = schoolRepository.save(school)
+        sut.updateAddress(entity.getId(), modifiedAddress)
+
+        def result = schoolRepository.findAll()
+
+        then:
+        result.get(0).getSchoolAddress() == modifiedAddress
+
+    }
+
+    def "schoolRepository update - dirty checking fail"() {
+
+        given:
+        String inputAddress = "의왕시 오전동"
+        String modifiedAddress = "의왕시 고천동"
+        String name = "모락중학교"
+
+        def school = School.builder()
+                .schoolAddress(inputAddress)
+                .schoolName(name)
+                .build()
+
+        when:
+        def entity = schoolRepository.save(school)
+        sut.updateAddressWithoutTransaction(entity.getId(), modifiedAddress)
+
+        def result = schoolRepository.findAll()
+
+        then:
+        result.get(0).getSchoolAddress() == inputAddress
+
+    }
+
+}


### PR DESCRIPTION
영속성 컨텍스트 dirty checking 에 대한 이해를 돕기 위해
Service 코드를 작성하였고 그에 대한 테스트 코드까지 작성하였다.
@Transactional 를 붙이면 JPA가 관리하는 영속성 범위에 들어가며
entity 를 변경하는 순간 JPA 는 기존에 있던 것과 비교하여
(Dirty Checking) 트랜잭션이 끝나는 시점에 DB에 반영해준다.

따라서 entity 를 변경해주는 곳에는 @Transactional 을 붙이는 것을 기억하도록 하자.

참고서적 : 자바 ORM 표준 JPA 프로그래밍

+) 프로젝트 완성 시기에 이 부분은 필요 없기 때문에 지운다.

This closes #14 