### PR TITLE
생성시간/수정시간 자동화 구현

### DIFF
--- a/src/main/java/com/example/findmidschool/BaseTimeEntity.java
+++ b/src/main/java/com/example/findmidschool/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.example.findmidschool;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/src/main/java/com/example/findmidschool/FindMidSchoolApplication.java
+++ b/src/main/java/com/example/findmidschool/FindMidSchoolApplication.java
@@ -2,7 +2,9 @@ package com.example.findmidschool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FindMidSchoolApplication {
 

--- a/src/main/java/com/example/findmidschool/school/entity/School.java
+++ b/src/main/java/com/example/findmidschool/school/entity/School.java
@@ -4,6 +4,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+
+import com.example.findmidschool.BaseTimeEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class School {
+public class School extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/groovy/com/example/findmidschool/school/repository/SchoolRepositoryTest.groovy
+++ b/src/test/groovy/com/example/findmidschool/school/repository/SchoolRepositoryTest.groovy
@@ -4,6 +4,8 @@ import com.example.findmidschool.AbstractIntegrationContainerBaseTest
 import com.example.findmidschool.school.entity.School
 import org.springframework.beans.factory.annotation.Autowired
 
+import java.time.LocalDateTime
+
 class SchoolRepositoryTest extends AbstractIntegrationContainerBaseTest {
 
     @Autowired
@@ -60,6 +62,28 @@ class SchoolRepositoryTest extends AbstractIntegrationContainerBaseTest {
 
         then:
         result.size() == 1
+
+    }
+
+    def "BaseTimeEntity 등록"() {
+
+        given:
+        LocalDateTime now = LocalDateTime.now()
+        String address = "의왕시 오전동"
+        String name = "모락중학교"
+
+        def school = School.builder()
+                .schoolAddress(address)
+                .schoolName(name)
+                .build()
+
+        when:
+        schoolRepository.save(school)
+        def result = schoolRepository.findAll()
+
+        then:
+        result.get(0).getCreatedDate().isAfter(now)
+        result.get(0).getModifiedDate().isAfter(now)
 
     }
 


### PR DESCRIPTION
생성시간/수정시간은 공통적으로 쓰는 필드기 때문에
추상 클래스를 사용하였다. 이때 추상 클래스에는
`@MappedSuperClass`, 
`@EntityListeners(AuditingEntityListener.class)`
를 붙여주며 main 함수를 실행하는 class 에는
`@EnableJpaAuditing` 을 붙여준다.
당연한 이야기지만 추상 클래스를 상속받기 위해서는
extends "추상 클래스" 를 붙여줘야 한다.

This closes #16 